### PR TITLE
Include yiisoft/view version 9 into require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "yiisoft/mailer",
+    "name": "rossaddison/mailer",
     "type": "library",
     "description": "Yii Mailer Library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "psr/event-dispatcher": "^1.0",
-        "yiisoft/view": "^6.0|^7.0|^8.0"|^9.0"
+        "yiisoft/view": "^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^8.1",
         "psr/event-dispatcher": "^1.0",
-        "yiisoft/view": "^6.0|^7.0|^8.0"
+        "yiisoft/view": "^6.0|^7.0|^8.0"|^9.0"
     },
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "suggest": {
         "yiisoft/event-dispatcher": "Yii Event Dispatcher",
         "yiisoft/mailer-swiftmailer": "Yii Mailer Library - Swift Mailer Extension",
-        "yiisoft/mailer-symfony": "Yii Mailer Library - Symfony Mailer Extension"
+        "rossaddison/mailer-symfony": "Yii Mailer Library - Symfony Mailer Extension"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

Hi Vjik,
Please can you include version 9 into composer so that I can include yiisoft/mailer in rossaddison/demo instead of rossaddison/mailer.
